### PR TITLE
Update hacdias.com to point at /uses page

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -83,7 +83,7 @@
     { "name": "Jack Baty", "url": "https://baty.net/posts/2023/11/app-defaults", "rss": "https://baty.net/feed", "date": "2023-11-08 18:46"},
     { "name": "Mandaris", "url": "https://mandarismoore.com/2023/11/08/defaults-in.html", "rss": "https://mandarismoore.com/feed.xml", "date": "2023-11-08 19:35" },
     { "name": "Robin Opletal", "url": "https://robinopletal.com/posts/default-apps-fall-2023", "rss": "https://robinopletal.com/rss.xml", "date": "2023-11-08 20:26"},
-    { "name": "Henrique Dias", "url": "https://hacdias.com/2023/11/08/app-defaults-late-2023/", "rss": "https://hacdias.com/feed.xml", "date": "2023-11-08 13:06"},
+    { "name": "Henrique Dias", "url": "https://hacdias.com/uses/#software", "rss": "https://hacdias.com/feed.xml", "date": "2024-01-02 19:59"},
     { "name": "Tim Bornholdt", "url": "https://timbornholdt.com/blog/my-default-apps-at-the-end-of-2023", "rss": "https://timbornholdt.com/blog/feed.rss", "date": "2023-11-08 21:50"},
     { "name": "Cedric", "url": "https://www.cedricbonhomme.org/2023/11/08/my-default-apps-at-the-end-of-2023/", "rss": "https://www.cedricbonhomme.org/blog/index.xml", "date": "2023-11-08 22:07"},
     { "name": "Alberto Marinucci", "url": "https://alby.xyz/index.php/2023/11/08/le-mie-app-di-default-2023/", "rss": "https://alby.xyz/index.php/feed/", "date": "2023-11-08 22:29"},


### PR DESCRIPTION
I realised my App Defaults post was basically just an updated version of the software section of the uses page. If you think this is fine, I think it's better to point it there, as that'll be more up to date.