### PR TITLE
Fixed maymeow URL and rss

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -56,7 +56,7 @@
     { "name": "Dmitry Dolzhenko", "url": "https://dolzhenko.me/blog/2023/11/default-apps/", "rss": "https://dolzhenko.me/feed.xml", "date": "2023-11-07 22:00" },
     { "name": "Paweł Orzech", "url": "https://pawel.orzech.me/2023/11/07/my-defaults.html", "rss": "https://pawel.orzech.me/rss", "date": "2023-11-07 21:17" },
     { "name": "Konstantin Tutsch", "url": "https://konstantintutsch.com/my-app-defaults-because-everyone-is-doing-them/", "rss": "https://konstantintutsch.com/feed.xml", "date": "2023-11-07 21:26"},
-    { "name": "May", "url": "https://maymeow.substack.com/p/my-app-defaults-2023-edition/", "rss": "https://maymeow.substack.com/feed", "date": "2023-11-07 21:28" },
+    { "name": "May", "url": "https://maymeow.com/defaults/", "rss": "https://maymeow.com/index.xml", "date": "2023-11-07 21:28" },
     { "name": "Jonas Brusman", "url": "https://jonas.brusman.se/my-default-apps-at-the-end-of-2023/", "rss": "https://jonas.brusman.se/rss.xml", "date": "2023-11-07 22:59" },
     { "name": "humdrum", "url": "https://tiv.today/2023/11/defaultapps", "rss": "https://tiv.today/feed.rss", "date": "2023-11-07 21:51" },
     { "name": "Yury Molodtsov", "url": "https://molodtsov.me/2023/11/my-default-apps/", "rss": "https://molodtsov.me/blog/index.xml", "date": "2023-11-07 22:30" },


### PR DESCRIPTION
I fixed the URL for the "defaults: page and the RSS feed since I moved my website back to being self-hsoted.