### PR TITLE
Update entry for myles braithwaite (new domain)

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -387,7 +387,7 @@
     { "name": "Gabz (2024)", "url": "https://gabz.blog/posts/default-apps-2024-edition", "rss": "https://gabz.blog/feed.xml" , "date": "2024-09-03 12:30"},
     { "name": "Erlend", "url": "https://havn.blog/2024/09/12/my-app-defaults.html", "rss": "https://havn.blog/categories/english/feed.xml", "date": "2024-09-13 13:15" },
     { "name": "Jacob Asker", "url": "https://imjacob.pika.page/posts/my-app-defaults", "rss": "https://imjacob.pika.page/posts_feed", "date": "2024-09-18 11:20" },
-    { "name": "myles braithwaite", "url": "https://mylesb.ca/defaults", "rss": "https://myles.social/feed.xml", "date": "2024-09-27 15:47" },
+    { "name": "myles braithwaite", "url": "https://myles.garden/defaults", "rss": "https://myles.garden/feed.xml", "date": "2024-09-27 15:47" },
     { "name": "Kirsty (2024)", "url": "https://nocto.com/posts/app-defaults-2024", "rss": "https://nocto.com/posts/rss.xml" , "date": "2024-11-07 10:00"},
     { "name": "Tobias Horvath", "url": "https://tobyx.com/2024/defaults", "rss": "https://tobyx.com/atom.xml" , "date": "2024-11-10 00:00"},
     { "name": "Norangebit", "url": "https://norangeb.it/defaults", "rss": "https://norangeb.it/index.xml" , "date": "2024-11-21 00:00"},


### PR DESCRIPTION
Updated my entry to reflect my new domain, `myles.garden`. I've moved away from Micro.blog and now run my own site.